### PR TITLE
Trailing feature

### DIFF
--- a/binance.js
+++ b/binance.js
@@ -1,8 +1,5 @@
-const { TESTNET_URLS, MAINNET_URLS } = require('./constants');
+const { TESTNET_URLS, MAINNET_URLS, TEST_MODE } = require('./constants');
 const Binance = require('node-binance-api');
-
-// set TEST_MODE = false to switch to the mainnet with REAL money
-const TEST_MODE = true;
 
 const { API_KEY_TEST, API_SECRET_TEST, API_KEY_MAIN, API_SECRET_MAIN } = process.env;
 

--- a/constants.js
+++ b/constants.js
@@ -14,5 +14,6 @@ const MAINNET_URLS = {
   combineStream: 'wss://stream.binance.com:9443/stream?streams=',
   stream: 'wss://stream.binance.com:9443/ws/',
 };
+const TEST_MODE = true;
 
-module.exports = { MARKET_FLAG, FIATS, TESTNET_URLS, MAINNET_URLS };
+module.exports = { MARKET_FLAG, FIATS, TESTNET_URLS, MAINNET_URLS, TEST_MODE };

--- a/constants.js
+++ b/constants.js
@@ -1,8 +1,8 @@
 const MARKET_FLAG = { type: 'MARKET' };
 
-// # List of pairs to exclude
-// # by default we're excluding the most popular fiat pairs
-// # and some margin keywords, as we're only working on the SPOT account
+// List of pairs to exclude
+// by default we're excluding the most popular fiat pairs
+// and some margin keywords, as we're only working on the SPOT account
 const FIATS = ['EURUSDT', 'GBPUSDT', 'JPYUSDT', 'USDUSDT', 'DOWN', 'UP'];
 const TESTNET_URLS = {
   base: 'https://testnet.binance.vision/api/',
@@ -14,6 +14,11 @@ const MAINNET_URLS = {
   combineStream: 'wss://stream.binance.com:9443/stream?streams=',
   stream: 'wss://stream.binance.com:9443/ws/',
 };
+
+// set TEST_MODE = false to switch to the mainnet with REAL money
 const TEST_MODE = true;
 
-module.exports = { MARKET_FLAG, FIATS, TESTNET_URLS, MAINNET_URLS, TEST_MODE };
+// set TRAILING_MODE = false to sell whenever an asset hits the TP threshold
+const TRAILING_MODE = true;
+
+module.exports = { MARKET_FLAG, FIATS, TESTNET_URLS, MAINNET_URLS, TEST_MODE, TRAILING_MODE };

--- a/constants.js
+++ b/constants.js
@@ -1,8 +1,9 @@
 const MARKET_FLAG = { type: 'MARKET' };
 
-// List of pairs to exclude
-// by default we're excluding the most popular fiat pairs
-// and some margin keywords, as we're only working on the SPOT account
+/* List of pairs to exclude
+  by default we're excluding the most popular fiat pairs
+  and some margin keywords, as we're only working on the SPOT account
+*/
 const FIATS = ['EURUSDT', 'GBPUSDT', 'JPYUSDT', 'USDUSDT', 'DOWN', 'UP'];
 const TESTNET_URLS = {
   base: 'https://testnet.binance.vision/api/',
@@ -15,10 +16,21 @@ const MAINNET_URLS = {
   stream: 'wss://stream.binance.com:9443/ws/',
 };
 
-// set TEST_MODE = false to switch to the mainnet with REAL money
+// Set TEST_MODE = false to switch to the mainnet with REAL money
 const TEST_MODE = true;
 
-// set TRAILING_MODE = false to sell whenever an asset hits the TP threshold
+/* 
+ Every time an asset hits the TP, the bot doesn't sell it immediately. 
+ The SL and TP threshold of that asset is increased.
+ If an asset hits the SL, we sell (In fact, we just sell at SL).
+
+ For example, BTCUSDT is bought at 100. TP is 106 (6%) and SL is 97 (3%). 
+ When it hits 106, the TP is adjusted to ~106 and SL is ~103. 
+ Whenever it hits SL (97 or 103...), the bot sells.
+
+Disable this feature by setting "TRAILING_MODE" to false
+*/
+
 const TRAILING_MODE = true;
 
 module.exports = { MARKET_FLAG, FIATS, TESTNET_URLS, MAINNET_URLS, TEST_MODE, TRAILING_MODE };

--- a/functions/buy.js
+++ b/functions/buy.js
@@ -3,8 +3,7 @@ const binance = require('../binance');
 const { MARKET_FLAG } = require('../constants');
 const { returnPercentageOfX } = require('./helpers');
 
-const { VOLATILE_TRIGGER, INTERVAL, QUANTITY, MIN_QUANTITY, PAIR_WITH, TP_THRESHOLD, SL_THRESHOLD } =
-  process.env;
+const { VOLATILE_TRIGGER, INTERVAL, QUANTITY, MIN_QUANTITY, TP_THRESHOLD, SL_THRESHOLD } = process.env;
 
 const calculatePortfolioValue = (portfolio) => {
   let value = 0;
@@ -70,10 +69,12 @@ const handleBuy = async (volatiles) => {
           symbol,
           quantity,
           orderId: purchaseData.orderId,
-          price: Number(price),
+          bought_at: Number(price),
+          order_ATH: Number(price),
           TP_Threshold: Number(price) + returnPercentageOfX(Number(price), TP_THRESHOLD),
           SL_Threshold: Number(price) - returnPercentageOfX(Number(price), SL_THRESHOLD),
           purchase_time: new Date().toLocaleString(),
+          updated_at: new Date().toLocaleString(),
         };
         portfolio.push(orderData);
         console.log(`Successfully place an order: ${JSON.stringify(orderData)}`);

--- a/functions/buy.js
+++ b/functions/buy.js
@@ -33,16 +33,18 @@ const calculateBuyingQuantity = async (symbol, length, portfolio) => {
     // The budget is splited equally for each order
     let allowedAmountToSpend = QUANTITY / length;
 
-    // Generally the bot will not spend 100% (only like 98-99%) of the budget because the the actual quantity is rounded down
-    // Do not buy if current portolio value is greater than 90% of the orignal quantity
+    /* Generally the bot will not spend 100% (only like 98-99%) of the budget because the the actual quantity is rounded down
+     Do not buy if current portolio value is greater than 90% of the orignal quantity */
     if (currentPortfolioValue >= returnPercentageOfX(QUANTITY, 90)) {
       throw `Current portfolio value exceeds the initial quantity, waiting for the current asset(s) to be sold first...`;
     }
 
-    // In case the allowed amount smaller than the min qty, proceed to buy the with the min qty
-    // For example in an interval, there are 4 coins to buy and the budget is 30...
-    // since you can't buy with 30/4 = 7.5 USDT, the allowed amount is increased to 11
-    // In this case, only the first two coins in this batch will be bought at 11 USDT each, 8 USDT won't be spent
+    /* 
+      In case the allowed amount smaller than the min qty, proceed to buy the with the min qty
+      For example in an interval, there are 4 coins to buy and the budget is 30...
+      since you can't buy with 30/4 = 7.5 USDT, the allowed amount is increased to 11
+      In this case, only the first two coins in this batch will be bought at 11 USDT each, 8 USDT won't be spent
+    */
     if (allowedAmountToSpend < MIN_QUANTITY) {
       allowedAmountToSpend = MIN_QUANTITY;
     }


### PR DESCRIPTION
 Every time an asset hits the TP, the bot doesn't sell it immediately. 
 The SL and TP threshold of that asset is increased.
 If an asset hits the SL, we sell (In fact, we just sell at SL).

 For example, BTCUSDT is bought at 100. TP is 106 (6%) and SL is 97 (3%). 
 When it hits 106, the TP is adjusted to ~106 and SL is ~103. 
 Whenever it hits SL (97 or 103...), the bot sells.